### PR TITLE
add send slack message to ci/cd workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,3 +36,13 @@ jobs:
       # Linting
       - name: lint server
         run: cd backend && npm run lint
+
+      # Send slack message to ci/cd channel
+      - name: Notify on slack
+        if: always()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,pullRequest
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,10 +39,11 @@ jobs:
 
       # Send slack message to ci/cd channel
       - name: Notify on slack
-        if: always()
+        if: ${{ github.event_name == 'pull_request' }}
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
-          fields: repo,message,commit,author,action,eventName,pullRequest
+          fields: author,pullRequest,message,commit
+          custom_payload: "{text: 'Code review waiting'}"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,4 +45,4 @@ jobs:
           status: ${{ job.status }}
           fields: repo,message,commit,author,action,eventName,pullRequest
         env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
-          fields: author,pullRequest,message,commit
-          custom_payload: "attachments: [{{text: 'Code review waiting'}}]"
+          fields: author,pullRequest,commit
+          text: 'Code review waiting'
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,6 +44,6 @@ jobs:
         with:
           status: ${{ job.status }}
           fields: author,pullRequest,message,commit
-          custom_payload: "{text: 'Code review waiting'}"
+          custom_payload: "attachments: [{{text: 'Code review waiting'}}]"
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
This workflow update should send messages from github actions workflow to new slack channel "cicd_messages".