### PR TITLE
Few helper functions for determining if conversation is a thread

### DIFF
--- a/backend/utils/filterSlackResponse.js
+++ b/backend/utils/filterSlackResponse.js
@@ -5,7 +5,7 @@ const GetHumanMessagesFromSlack = (messages) => {
   return result.reverse()
 }
 
-const messageIsThreaded = (message) => message.hasOwnProperty('thread_ts')
+const messageIsThreaded = (message) => Object.prototype.hasOwnProperty.call(message, 'thread_ts')
 
 const addThreadArrayToEachMessage = (message) => {
   message.thread_array = []

--- a/backend/utils/filterSlackResponse.js
+++ b/backend/utils/filterSlackResponse.js
@@ -5,6 +5,20 @@ const GetHumanMessagesFromSlack = (messages) => {
   return result.reverse()
 }
 
+const messageIsThreaded = (message) => message.hasOwnProperty('thread_ts')
+
+const addThreadArrayToEachMessage = (message) => {
+  message.thread_array = []
+}
+
+const GetThreads = (messages) => {
+  const result = messages.filter((message) => {
+    addThreadArrayToEachMessage(message)
+    return messageIsThreaded(message)
+  })
+  return result
+}
+
 const GetWordsFromMessages = (messages) => {
   const result = []
   messages.forEach((message) => {
@@ -26,4 +40,5 @@ module.exports = {
   GetHumanMessagesFromSlack,
   GetWordsFromMessages,
   GetRealNamesFromSlack,
+  GetThreads,
 }

--- a/backend/utils/importHistory.js
+++ b/backend/utils/importHistory.js
@@ -4,6 +4,7 @@ const {
   GetHumanMessagesFromSlack,
   GetWordsFromMessages,
   GetRealNamesFromSlack,
+  GetThreads,
 } = require('./filterSlackResponse')
 
 async function importHistory(channelId, slackToken, res) {
@@ -23,6 +24,7 @@ async function importHistory(channelId, slackToken, res) {
 
     const messages = GetHumanMessagesFromSlack(result.messages)
     const messagesWithNames = GetRealNamesFromSlack(messages, members)
+    const threadedMessages = GetThreads(messages)
     const words = GetWordsFromMessages(messages)
     res.json({ messages: messagesWithNames, words: words })
   } catch (error) {

--- a/backend/utils/importHistory.js
+++ b/backend/utils/importHistory.js
@@ -4,7 +4,6 @@ const {
   GetHumanMessagesFromSlack,
   GetWordsFromMessages,
   GetRealNamesFromSlack,
-  GetThreads,
 } = require('./filterSlackResponse')
 
 async function importHistory(channelId, slackToken, res) {
@@ -24,7 +23,6 @@ async function importHistory(channelId, slackToken, res) {
 
     const messages = GetHumanMessagesFromSlack(result.messages)
     const messagesWithNames = GetRealNamesFromSlack(messages, members)
-    const threadedMessages = GetThreads(messages)
     const words = GetWordsFromMessages(messages)
     res.json({ messages: messagesWithNames, words: words })
   } catch (error) {


### PR DESCRIPTION
Added few functions. One functions adds the desired 'thread_array' field which is array of threads. One checks if the conversation or message is a thread or is threaded by looking at the 'thread_ts' field. One function returns every conversation which is a thread. A different API call is needed to actually to get the text in the threads.