### PR TITLE
First entries in backend to make enable parameters in data import

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -2,6 +2,7 @@ require('dotenv').config()
 const express = require('express')
 const app = express()
 var importHistory = require('./utils/importHistory.js')
+const parseSlackTimestamp = require('./utils/parseSlackTimestamp')
 const slackToken = process.env.SLACK_TOKEN
 const cors = require('cors')
 
@@ -10,7 +11,7 @@ app.use(express.static('build'))
 
 app.use(
   express.urlencoded({
-    extended: true
+    extended: true,
   })
 )
 
@@ -21,11 +22,15 @@ app.get('/api/data/:channelid', (req, res) => {
   importHistory(req.params.channelid, slackToken, res)
 })
 
-app.post('/api/paramizedData', (req, res) => {
-  const now = Date.now();
-  console.log(now);
-  console.log(req.body)
-  res.send(req.body)
+app.post('/api/data', (req, res) => {
+  //expects a post with data in format, all parameters are optional: {"channel": CHANNEL_ID, "hours": HOW_MANY_HOURS_BACK, "user": USER_ID}
+  var channel = req.body.channel || 'C02UNV80V7B'
+  var oldest = parseSlackTimestamp(req.body.hours)
+  var user = req.body.user
+
+  //importHistory(slackToken, res, channel, oldest, user) still to be implemented
+
+  res.json({'channel': channel, 'oldest': oldest, 'user': user})
 })
 
 module.exports = app

--- a/backend/app.js
+++ b/backend/app.js
@@ -8,9 +8,24 @@ const cors = require('cors')
 app.use(cors())
 app.use(express.static('build'))
 
+app.use(
+  express.urlencoded({
+    extended: true
+  })
+)
+
+app.use(express.json())
+
 //you will need valid channel ids for testing
 app.get('/api/data/:channelid', (req, res) => {
   importHistory(req.params.channelid, slackToken, res)
+})
+
+app.post('/api/paramizedData', (req, res) => {
+  const now = Date.now();
+  console.log(now);
+  console.log(req.body)
+  res.send(req.body)
 })
 
 module.exports = app

--- a/backend/utils/parseSlackTimestamp.js
+++ b/backend/utils/parseSlackTimestamp.js
@@ -1,0 +1,10 @@
+function parseSlackTimestamp(hours) {
+  if (hours){
+    const now = Date.now() * 1000 //microseconds
+    const timestamp = (now - hours * 60 * 60 * 1000000).toString()
+    return timestamp.substring(0, 10) + '.' + timestamp.substring(10, 16)
+  }
+  return '1000000000.000000'
+}
+
+module.exports = parseSlackTimestamp


### PR DESCRIPTION
I created a app.post('/api/data' ... ) function to accept a post with parameters, in order to call the import function with parameters.
Also a parseSlackTimestamp function in the utils folder to, well, parse Slack timestamps.