### PR TITLE
User should be able to define parameters

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -2,7 +2,7 @@ require('dotenv').config()
 const express = require('express')
 const app = express()
 var importHistory = require('./utils/importHistory.js')
-const parseSlackTimestamp = require('./utils/parseSlackTimestamp')
+const { parseTimestamp } = require('./utils/parseSlackTimestamp')
 const slackChannels = require('./utils/slackChannels.js')
 const slackUsers = require('./utils/slackUsers.js')
 const slackToken = process.env.SLACK_TOKEN
@@ -32,9 +32,9 @@ app.get('/api/users', (req, res) => {
 })
 
 app.post('/api/data', (req, res) => {
-  //expects a post with data in format, all parameters are optional: {"channel": CHANNEL_ID, "hours": HOW_MANY_HOURS_BACK, "user": USER_ID}
-  var channel = req.body.channel || 'C02UNV80V7B'
-  var oldest = parseSlackTimestamp(Date.now() * 1000, req.body.hours)
+  //expects a post with data in format, all parameters are optional: {"channel": CHANNEL_NAME, "hours": HOW_MANY_HOURS_BACK, "user": USER_NAME}
+  var channel = req.body.channel || 'general'
+  var oldest = parseTimestamp(Date.now() * 1000, req.body.hours)
   var user = req.body.user
 
   importHistory(channel, slackToken, res, oldest, user)

--- a/backend/tests/unit/parseSlackTimestamp.test.js
+++ b/backend/tests/unit/parseSlackTimestamp.test.js
@@ -1,10 +1,9 @@
-const parseSlackTimestamp = require('../../utils/parseSlackTimestamp')
+const { parseTimestamp } = require('../../utils/parseSlackTimestamp')
 
 test('The correct timestamp is returned', () => {
   const now = Date.now() * 1000
   const hours = 24
-  var correctStamp = (now - hours * 60 * 60 * 1000000).toString()
-  correctStamp = correctStamp.substring(0, 10) + '.' + correctStamp.substring(10, 16)
-  const timestamp = parseSlackTimestamp(now, hours)
+  var correctStamp = now - hours * 60 * 60 * 1000000
+  const timestamp = parseTimestamp(now, hours)
   expect(timestamp).toBe(correctStamp)
 })

--- a/backend/utils/filterSlackResponse.js
+++ b/backend/utils/filterSlackResponse.js
@@ -1,4 +1,4 @@
-const { slackTimeOlder, parseTimestampFromSlackTs } = require('./parseSlackTimestamp')
+const { parseTimestampFromSlackTs } = require('./parseSlackTimestamp')
 
 const GetHumanMessagesFromSlack = (messages) => {
   const result = messages.filter((obj) => {
@@ -92,7 +92,7 @@ const filterOutOldMessages = (messages, oldest) => {// eslint-disable-line
     var thArrln = message.thread_array.length
     if (thArrln > 0){
       if (parseTimestampFromSlackTs(message.thread_array[thArrln-1].ts) < oldest){//the whole thread and parent can be ignored
-        continue;
+        continue
       } else if (parseTimestampFromSlackTs(message.thread_array[0].ts) < oldest){//only parts of the thread should be included
         var newThread = []
         for (var j = message.thread_array.length-1; j >= 0; j--){
@@ -107,10 +107,11 @@ const filterOutOldMessages = (messages, oldest) => {// eslint-disable-line
       }
     }
     if (parseTimestampFromSlackTs(message.ts) < oldest && message.thread_array.length > 0){//parent is too old but there's relevant messages in the thread
-      message.text = ":Start-of-thread-is-outside-of-timelimit"
-      message.real_name = "Comment by bot"
+      message.text = ':The-start-of-this-thread-is-outside-of-timelimit'
+      message.real_name = 'Comment by bot'
+      message.user = 'xxxxx'
       newMessages.push(message)
-    } else if (parseTimestampFromSlackTs(message.ts) > oldest){
+    } else if (parseTimestampFromSlackTs(message.ts) > oldest){//message is ok to push to array
       newMessages.push(message)
     }
   }

--- a/backend/utils/importHistory.js
+++ b/backend/utils/importHistory.js
@@ -51,7 +51,7 @@ async function importHistory(channel, slackToken, res, oldest, user) {
   } catch (error) {
     if (error){
       console.error(error)
-      res.send("Error in getting data.")
+      res.send('Error in getting data.')
     }
   }
 }

--- a/backend/utils/parseSlackTimestamp.js
+++ b/backend/utils/parseSlackTimestamp.js
@@ -1,9 +1,12 @@
-function parseSlackTimestamp(now, hours) {
+function parseTimestamp(now, hours) {
   if (hours){
-    const timestamp = (now - hours * 60 * 60 * 1000000).toString()
-    return timestamp.substring(0, 10) + '.' + timestamp.substring(10, 16)
+    return now - hours * 60 * 60 * 1000000
   }
-  return null
+  return false
 }
 
-module.exports = parseSlackTimestamp
+function parseTimestampFromSlackTs(slackTimestamp){
+  return parseInt(slackTimestamp.replace('.', ''))
+}
+
+module.exports = { parseTimestamp, parseTimestampFromSlackTs }

--- a/front/.eslintrc.js
+++ b/front/.eslintrc.js
@@ -23,10 +23,6 @@ module.exports = {
       'error',
       2
     ],
-    'linebreak-style': [
-      'error',
-      'unix'
-    ],
     'quotes': [
       'error',
       'single'

--- a/front/src/services/messages.js
+++ b/front/src/services/messages.js
@@ -1,6 +1,6 @@
 import axios from 'axios'
 
-const channel = 'C02UNV80V7B'
+const channel = 'general'
 const baseUrl = `http://${window.location.hostname}:80/api/data/${channel}`
 
 const getAll = async() => {


### PR DESCRIPTION
First running version of timefilter. It's a quite complex loop because we can't use the built in timefilter in the Slack api, because then we would not be able to serve thread messages that are after the timeline.

PR now to alleviate potential merge conflicts. Will start working on tests for the filter after this.