### PR TITLE
environment variable for backend-port

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,14 @@ Run using Docker with:
 docker build -t [name] .  
 docker run -it -p [your port]:8080 [name] (use 8080 as your port unless you want to change the backend port within the frontend code)
 ```
-Or run with npm (the server will start on port 8080):
+Or run with npm (the server will start on port 80):
 ```bash
 npm install  
 npm run build  
 npm start  
-```
+```  
+When starting frontend and backend separately from their respective 
+folder (e.g. while developing), you can use environment variables 
+REACT_APP_BACKEND_PORT and PORT to 
+choose on which port the backend serves data (both variables should be 
+used at the same time).

--- a/front/src/services/messages.js
+++ b/front/src/services/messages.js
@@ -1,7 +1,8 @@
 import axios from 'axios'
 
+const port = process.env.REACT_APP_BACKEND_PORT || 80
 const channel = 'general'
-const baseUrl = `http://${window.location.hostname}:80/api/data/${channel}`
+const baseUrl = `http://${window.location.hostname}:${port}/api/data/${channel}`
 
 const getAll = async() => {
   const res = await axios.get(baseUrl)


### PR DESCRIPTION
When starting back- and frontend separately one can use REACT_APP_BACKEND_PORT and PORT-variables for choosing which port for backend api.