### PR TITLE
update slashcommand api

### DIFF
--- a/backend/controllers/slackController.js
+++ b/backend/controllers/slackController.js
@@ -16,6 +16,7 @@ async function saveQuery(res, args) {
         text: {
           type: 'mrkdwn',
           text: `Your query is ready at : http://135.181.37.120:80/api/parse/${id}`,
+          //text: `Your query is ready at : http://localhost/api/parse/${id}`,
         },
       }
     ],
@@ -27,12 +28,12 @@ async function returnQuery(res, id) {
     if (id in savedQueries) {
       res.send(savedQueries[id])
     } else {
-      res.sendStatus(401)
+      res.sendStatus(400)
     }
   } catch (error) {
     if (error) {
       console.error(error)
-      res.sendStatus(501)
+      res.sendStatus(500)
     }
   }
 }

--- a/backend/utils/parseParameters.js
+++ b/backend/utils/parseParameters.js
@@ -1,16 +1,23 @@
-const { getChannels } = require('../services/slackService.js')
+const { slackService } = require('../services/slackService')
+const { slackClient } = require('../services/slackClient')
+const slack = slackService({ slackClient })
 const { parseTimestamp } = require('./parseSlackTimestamp.js')
+
+function isNumeric(val) {
+  return /^-?\d+$/.test(val)
+}
 
 const parameterIsUsername = (param) => {
   return param.charAt(0) === '@'
 }
 
 const parameterIsHours = (param) => {
-  return !isNaN(parseInt(param))
+  return isNumeric(param)
 }
 
-const parameterIsValidChannel = (param) => {
-  const validChannels = getChannels()
+const parameterIsValidChannel = async (param) => {
+  const validChannels = await slack.getChannels()
+
   for (const channel in validChannels) {
     if (param === channel) {
       return true
@@ -19,34 +26,53 @@ const parameterIsValidChannel = (param) => {
   return false
 }
 
-const parseParameters = (parameters) => {
+const parseParameters = (parameters, source_channel) => {
   //expects a post with data in format, all parameters are optional: {"channel": CHANNEL_NAME, "user": USER_NAME, "hours": HOW_MANY_HOURS_BACK}
   if (parameters.length === 0) {
-    const channel = 'general'
-    const args = { channel }
+    const channel = source_channel
+    const user = null
+    const oldest = parseTimestamp(Date.now() * 1000, null)
+    const args = { channel, user, oldest }
     return args
   }
   if (parameters.length === 1) {
+    
     if (parameterIsHours(parameters[0])) {
       const hours = parameters[0]
       const oldest = parseTimestamp(Date.now() * 1000, hours)
-      const args = { oldest }
+      const channel = source_channel
+      const user = null
+      const args = { channel, user, oldest }
       return args
     }
-    if (parameterIsUsername(parameters[0])) {
+    else if (parameterIsUsername(parameters[0])) {
       const user = parameters[0]
-      const args = { user }
+      const oldest = parseTimestamp(Date.now() * 1000, null)
+      const channel = source_channel
+      const args = { channel, user, oldest }
       return args
     }
-    if (parameterIsValidChannel(parameters[0])) {
+    else if (parameterIsValidChannel(parameters[0])) {
+      
       const channel = parameters[0]
-      const args = { channel }
+      const user = null
+      const oldest = parseTimestamp(Date.now() * 1000, null)
+      const args = { channel, user, oldest }
       return args
     }
+  }
+  if (parameters.length === 3) {
+    const channel = parameters[0] || 'general'
+    // username wil be in format @user.name for example @aleksi.suuronen and needs to be implemented
+    const user = parameters[1]
+    const hours = parameters[2]
+    const oldest = parseTimestamp(Date.now() * 1000, hours)
+    const args = { channel, user, oldest }
+    return args
   }
   /**
    * @TODO: Fix to work with 2 parameters
    */
 }
 
-module.exports = {parseParameters}
+module.exports = { parseParameters }

--- a/backend/utils/slackErrorResponses.js
+++ b/backend/utils/slackErrorResponses.js
@@ -1,0 +1,15 @@
+const invalidAmountOfArguments = (number) => {
+  const obj = {
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `incorrect number of parameters : ${number}`,
+        },
+      },
+    ],
+  }
+  return obj
+}
+module.exports = invalidAmountOfArguments


### PR DESCRIPTION
update slashcommand api to work with 0,1,3 parameters and use channel where the command was from as default.
abit too much repetition in parseParameters while building args but cant refractor now. 