### PR TITLE
Refractor backend

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -2,14 +2,7 @@ require('dotenv').config()
 const express = require('express')
 const app = express()
 const cors = require('cors')
-const {
-  importHistory,
-  slackChannels,
-  slackUsers,
-  slackGetAllByUser,
-  returnQuery,
-  saveQuery,
-} = require('./controllers/slackController.js')
+const slackController = require('./controllers/slackController.js')
 const { parseTimestamp } = require('./utils/parseSlackTimestamp')
 const { parseParameters } = require('./utils/parseParameters')
 const { invalidNumberOfArguments,errorResponseObject } = require('./utils/slackErrorResponses')
@@ -28,19 +21,19 @@ app.get('/api/data/:channelId', (req, res) => {
   const oldest = parseTimestamp(Date.now() * 1000, req.body.hours)
   const user = req.body.user
   const args = { channel, user, oldest }
-  importHistory(res, args)
+  slackController.slackMessages(res, args)
 })
 
 app.get('/api/channels', (req, res) => {
-  slackChannels(res)
+  slackController.slackChannels(res)
 })
 
 app.get('/api/users', (req, res) => {
-  slackUsers(res)
+  slackController.slackUsers(res)
 })
 
 app.get('/api/users/:id', (req, res) => {
-  slackGetAllByUser(res, req.params.id)
+  slackController.slackGetAllByUser(res, req.params.id)
 })
 
 app.post('/api/data', (req, res) => {
@@ -49,7 +42,7 @@ app.post('/api/data', (req, res) => {
   const oldest = parseTimestamp(Date.now() * 1000, req.body.hours)
   const user = req.body.user
   const args = { channel, user, oldest }
-  importHistory(res, args)
+  slackController.slackMessages(res, args)
 })
 
 app.post('/api/parse', async (req, res) => {
@@ -58,7 +51,7 @@ app.post('/api/parse', async (req, res) => {
     const params = req.body.text.split(' ').filter(Boolean)
     if (params.length <= 3) {
       const parsedParams = await parseParameters(params, req.body.channel_name)
-      saveQuery(res, parsedParams)
+      slackController.saveQuery(res, parsedParams)
     } else {
       res.json(invalidNumberOfArguments(params.length))
     }
@@ -68,7 +61,7 @@ app.post('/api/parse', async (req, res) => {
 })
 
 app.get('/api/parse/:id', (req, res) => {
-  returnQuery(res, req.params.id)
+  slackController.returnQuery(res, req.params.id)
 })
 
 app.post('/api/sendJSON', (req, res) => {

--- a/backend/application/processSlackMessages.js
+++ b/backend/application/processSlackMessages.js
@@ -11,10 +11,6 @@ const {
 
 const categories = require('./categories.json')
 
-// TODO : Create parent function that does api calls all at once and remove args drilling or do this in controller
-// TODO : remove Unnecessary api calls, info is already somewhere.
-// TODO : Throw errors to controller that sends error response?
-
 async function processSlackMessages(slack, args) {
   // channel, oldest, user are contained in args
   const { channel } = args
@@ -45,7 +41,7 @@ async function addThreadsToMessages(slack, args) {
   const threadTimestamps = GetTimeStamps(threads)
   const promises = []
   var parentIndex = 0
-  console.time('apicalls')
+  
   try {
     // Send all api queries at once.
     for (let i = 0; i < threadTimestamps.length; i++) {
@@ -55,12 +51,11 @@ async function addThreadsToMessages(slack, args) {
       promises.push(apiResponse)
     }
     // Wait for all api queries to complete.
-    const threadsWithResponses = await Promise.all(promises)
+    const threadResponses = await Promise.all(promises)
     // Then process threads.
-    for (let i = 0; i < threadsWithResponses.length; i++) {
-      parentIndex = AddThreadToParent(threadsWithResponses[i], messages, parentIndex)
+    for (let i = 0; i < threadResponses.length; i++) {
+      parentIndex = AddThreadToParent(threadResponses[i], messages, parentIndex)
     }
-    console.timeEnd('apicalls')
     const resultObj = await addNamesToMessages(slack, messages, oldest, user)
     return resultObj
   } catch (error) {

--- a/backend/application/processSlackMessages.js
+++ b/backend/application/processSlackMessages.js
@@ -3,6 +3,7 @@ const {
   GetRealNamesFromSlack,
   GetThreads,
   GetTimeStamps,
+  GetHumanMessagesFromSlack,
   AddThreadToParent,
   filterOutOldMessages,
   filterMessagesByUser,
@@ -13,8 +14,35 @@ const categories = require('./categories.json')
 // TODO : Create parent function that does api calls all at once and remove args drilling or do this in controller
 // TODO : remove Unnecessary api calls, info is already somewhere.
 // TODO : Throw errors to controller that sends error response?
-async function addThreadsToMessages(res, slack, args) {
-  const {channelId, oldest, user, messages} = args
+
+async function processSlackMessages(slack, args) {
+  // channel, oldest, user are contained in args
+  const { channel } = args
+  try {
+    console.log('ch',channel)
+    const channels = await slack.getChannels()
+    console.log(channel)
+    var channelId = channels.channels.filter((obj) => {
+      return obj.name == channel || obj.id == channel
+    })[0].id
+    console.log('hdosahdfas')
+    const result = await slack.getChannelMessages(channelId)
+    let messages = result.reverse()
+
+    messages = GetHumanMessagesFromSlack(result)
+    args.messages = messages
+    args.channelId = channelId
+
+    const resultObj = await addThreadsToMessages(slack, args)
+    console.log(resultObj)
+    return resultObj
+  } catch (error) {
+    throw new Error(error.message)
+  }
+}
+
+async function addThreadsToMessages(slack, args) {
+  const { channelId, oldest, user, messages } = args
   const threads = GetThreads(messages)
   const threadTimestamps = GetTimeStamps(threads)
   try {
@@ -25,31 +53,33 @@ async function addThreadsToMessages(res, slack, args) {
       let threadWithReplies = await slack.getThreadMessages(query_args)
       parentIndex = AddThreadToParent(threadWithReplies, messages, parentIndex)
     }
-    const resultObj = await addNamesToMessages(res, slack, messages, oldest, user)
+    const resultObj = await addNamesToMessages(slack, messages, oldest, user)
     return resultObj
   } catch (error) {
     console.error(error)
   }
 }
 
-async function addNamesToMessages(res, slack, messages, oldest, user) {
+async function addNamesToMessages(slack, messages, oldest, user) {
   var members = {}
   const users = await slack.getUsers()
-  users.forEach((elem) => (members[elem.id] = { 'username': elem.username, 'real_name': elem.real_name }))
+  users.forEach(
+    (elem) => (members[elem.id] = { username: elem.username, real_name: elem.real_name })
+  )
   GetRealNamesFromSlack(messages, members)
   messages
     .filter((elem) => elem.thread_array.length > 0)
     .forEach((elem) => GetRealNamesFromSlack(elem.thread_array, members))
 
-  const result = applyFilters(res, messages, oldest, user)  
+  const result = applyFilters(messages, oldest, user)
   return result
 }
 
-function applyFilters(res, messages, oldest, user) {
+function applyFilters(messages, oldest, user) {
   if (oldest) messages = filterOutOldMessages(messages, oldest)
   if (user) messages = filterMessagesByUser(messages, user)
   const words = GetWordsFromMessages(messages)
   return { messages: messages, words: words, categories: categories }
 }
 
-module.exports = { addThreadsToMessages }
+module.exports = { processSlackMessages }

--- a/backend/controllers/hubspotController.js
+++ b/backend/controllers/hubspotController.js
@@ -22,13 +22,10 @@ const getAllContacts = async (res) => {
   }
 }
 
-const updateDeal = async (res, obj) => {
-  // NOT IMPLEMENTED YET
-  // TODO: CREATE NEEDED PROPERTIES FROM OBJ
-  // TODO: CREATE CUSTOM DEAL PROPERTIES IN HUBSPOT DEALS WEBSITE?
-  // TODO: ID REQUIRED ( How to find? )
+const updateDeal = async (res, id, properties) => {
+  // Placeholder for updateDeal, not working yet.
   try {
-    const result = await hubspot.updateDeal(obj)
+    const result = await hubspot.updateDeal(id, properties)
     if (result) res.send(result)
     else res.status(500).send('No result : updateDeal')
   } catch (error) {
@@ -37,11 +34,10 @@ const updateDeal = async (res, obj) => {
 }
 
 const createDeal = async (res, obj) => {
-  // Simple "placeholder". This works and deal is created to hubspot account but its mostly blank.
-  // TODO: Create custom properties for hubspot deals?
-  // TODO: Ask about possible hubspot test environment.
-  //const SimplePublicObjectInput = { dealname: 'NoNameForThisDeal', properties: obj }
-  //console.log('obj', obj)
+  // create new deal based on json sent from UI
+  // only customer & price are used for testing new deal creation.
+  // No custom properties space available atm.
+  // TODO: use existing custom properties to store our data? 
   try {
     const price = String(obj.Price || '').replace(/[^0-9,]+/g, '')
     //console.log(price)
@@ -51,7 +47,6 @@ const createDeal = async (res, obj) => {
         amount: `${Number(price) || 0}`,
       },
     }
-    //console.log(SimplePublicObjectInput)
 
     const result = await hubspot.createDeal(SimplePublicObjectInput)
     if (result.id) res.send('success')

--- a/backend/package.json
+++ b/backend/package.json
@@ -25,7 +25,8 @@
     "@slack/web-api": "^6.5.1",
     "cors": "^2.8.5",
     "dotenv": "^14.2.0",
-    "express": "^4.17.2"
+    "express": "^4.17.2",
+    "node-cache": "^5.1.2"
   },
   "devDependencies": {
     "eslint": "^8.7.0",

--- a/backend/services/hubspotService.js
+++ b/backend/services/hubspotService.js
@@ -1,7 +1,6 @@
 const hubspotService = ({ hubspotClient }) => {
-  
   const getAllDeals = async () => {
-    const limit = 10
+    const limit = 100
     const after = undefined
     const properties = undefined
     const propertiesWithHistory = undefined
@@ -17,23 +16,27 @@ const hubspotService = ({ hubspotClient }) => {
         associations,
         archived
       )
-      if (apiResponse.results) result = apiResponse.results
+      if (apiResponse.results) result = apiResponse.results.reverse()
     } catch (e) {
       throw new Error(`Error in getAll: ${e.message}`)
     }
     return result
   }
 
-  const getAllContacts = async () => {    
-    const allContacts = await hubspotClient.crm.contacts.getAll()
-    return allContacts
+  const getAllContacts = async () => {
+    try {
+      const allContacts = await hubspotClient.crm.contacts.getAll()
+      return allContacts
+    } catch (e) {
+      throw new Error(`Error in createAllContacts: ${e.message}`)
+    }
   }
 
   const createDeal = async (dealObject) => {
     try {
       const response = await hubspotClient.crm.deals.basicApi.create(dealObject)
       return response
-    } catch (e){
+    } catch (e) {
       throw new Error(`Error in createDeal: ${e.message}`)
     }
   }
@@ -44,7 +47,7 @@ const hubspotService = ({ hubspotClient }) => {
       const SimplePublicObjectInput = { properties }
       const response = await hubspotClient.crm.deals.basicApi.update(id, SimplePublicObjectInput)
       return response
-    } catch (e){
+    } catch (e) {
       throw new Error(`Error in createDeal: ${e.message}`)
     }
   }
@@ -53,7 +56,7 @@ const hubspotService = ({ hubspotClient }) => {
     getAllDeals,
     getAllContacts,
     createDeal,
-    updateDeal
+    updateDeal,
   })
 }
 module.exports = hubspotService

--- a/backend/services/slackService.js
+++ b/backend/services/slackService.js
@@ -7,11 +7,11 @@ const slackService = ({ slackClient }) => {
     const users = []
     let apiResult = undefined
     try {
-      let cacheResult = await slackCache.get('users')
+      const cacheResult = await slackCache.get('users')
       if (!cacheResult) {
         const newApiResult = await slackClient.users.list({})
-        const cacheSuccess = slackCache.set('users', newApiResult)
-        if (!cacheSuccess) throw new Error('set Cache error in getUsers')
+        const setCacheSuccess = slackCache.set('users', newApiResult)
+        if (!setCacheSuccess) throw new Error('set Cache error in getUsers')
         
         apiResult = newApiResult
       } else apiResult = cacheResult
@@ -28,8 +28,19 @@ const slackService = ({ slackClient }) => {
   }
 
   const getChannels = async () => {
+    let result = {}
     try {
-      const result = await slackClient.conversations.list({})
+      const cacheResult = await slackCache.get('channels')
+      if (!cacheResult) {
+        const newApiResult = await slackClient.conversations.list({})
+        console.log('NEW CALL : ', newApiResult)
+        const setCacheSuccess = slackCache.set('channels', newApiResult)
+        if (!setCacheSuccess) throw new Error('set Cache error in getChannels')        
+        result = newApiResult
+      } else{
+        result = cacheResult
+        console.log('FOUND IN CACHE, ', result)
+      }
       return result
     } catch (error) {
       throw new Error(`Error in getChannels: ${error}`)

--- a/backend/services/slackService.js
+++ b/backend/services/slackService.js
@@ -67,7 +67,6 @@ const slackService = ({ slackClient }) => {
 
   const getChannelMessages = async (channelId) => {
     try {
-      console.log('CHA ID: ', channelId)
       const apiResult = await slackClient.conversations.history({
         channel: channelId,
       })
@@ -77,7 +76,6 @@ const slackService = ({ slackClient }) => {
     }
   }
 
-  // TODO: not tested
   const getThreadMessages = async (args) => {
     try {
       const apiResult = await slackClient.conversations.replies(args)


### PR DESCRIPTION
While sending thread queries to slack, sends all request at once and waits for Promise.all()
Implement "node-cache" for users and channelnames. Time to live set at 10min.
Re-organize code little bit so its more uniform. ImportHistory() is now processSlackMessages and moved to application layer. Simple controller added for Slackmessages.