### PR TITLE
Added JSdoc to filterSlackResponse

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ![CI workflow](https://github.com/Ohtu-org/Serverless-data-parser-tool-for-project-proposals/actions/workflows/main.yml/badge.svg)
 
-![codecov](https://codecov.io/gh/Ohtu-org/Serverless-data-parser-tool-for-project-proposals/branch/main/graph/badge.svg?token=S2MQ8HYQ94)](https://codecov.io/gh/Ohtu-org/Serverless-data-parser-tool-for-project-proposals)
+![codecov](https://codecov.io/gh/Ohtu-org/Serverless-data-parser-tool-for-project-proposals/branch/main/graph/badge.svg?token=S2MQ8HYQ94)
 
 ## Tuntikirjanpito  
 [Linkki tuntikirjanpitoon](https://docs.google.com/spreadsheets/d/1cuh5_3st2fF5PlzxUwkLurNdqGqkFm90v7kIZbUjTgg/edit#gid=2125689465)

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,3 +1,4 @@
 module.exports = {
   testEnvironment: 'node',
+  setupFiles: ['./testModule'],
 }

--- a/backend/services/slackService.js
+++ b/backend/services/slackService.js
@@ -149,24 +149,6 @@ const slackService = ({ slackClient }) => {
     console.log('Result : ', result)
   }
 
-  /**
-   * A function which opens a modal after using a message shortcut in slack.
-   * @param {string} triggerId 
-   * @param {object} viewObject 
-   */
-  const sendModalView = async (triggerId, viewObject) => {
-    try {
-      const result = await slackClient.views.open({
-        trigger_id:triggerId,
-        view: viewObject,
-      })
-      console.log(result)
-    }
-    catch (error) {
-      console.error(error)
-    }
-  }
-
   return Object.freeze({
     getUsers,
     getChannels,
@@ -178,7 +160,6 @@ const slackService = ({ slackClient }) => {
     findAllByUser,
     sendMessage,
     getAllThreadsMessages,
-    sendModalView,
   })
 }
 

--- a/backend/testModule.js
+++ b/backend/testModule.js
@@ -1,0 +1,1 @@
+require('dotenv').config()

--- a/backend/tests/unit/parseParameters.test.js
+++ b/backend/tests/unit/parseParameters.test.js
@@ -1,7 +1,9 @@
 const {
   isNumeric,
   parameterIsUsername,
-  parameterIsHours
+  parameterIsHours,
+  parameterIsValidChannel,
+  parseParameters,
 } = require('../../utils/parseParameters')
 
 test('Hours are parsed and returned correctly with valid value', () => {
@@ -34,4 +36,46 @@ test('Numeric values are parsed and returned correctly',() => {
   expect(isNumeric(numeric)).toBeTruthy
   const notNumeric = 'general'
   expect(isNumeric(notNumeric)).toBeFalsy
+})
+
+test('Valid channel name is found correctly', async () => {
+  const channels = [
+    {
+      id: 'C02UCV0GQJZ',
+      name: 'channel-two',
+    },
+    {
+      id: 'C02UNV80V7B',
+      name: 'general',
+    },
+    {
+      id: 'C02V02LBQGG',
+      name: 'random',
+    },
+    {
+      id: 'C033WM9HGAZ',
+      name: 'demo_channel',
+    }
+  ]
+  const result = await parameterIsValidChannel(channels[3])
+  expect(result).toBeTruthy
+})
+
+test('Invalid channel name gives error correctly', async() => {
+  const result = await parameterIsValidChannel('Cat-pictures')
+  expect(result).toBeFalsy
+})
+
+test('Parameters are returned correctly if zero parameters', async() => {
+  const params = []
+  const sourceChannel = 'demo_channel'
+  const res = await parseParameters(params, sourceChannel)
+  expect(res).toStrictEqual(
+    {
+      'channel': sourceChannel,
+      'user': null,
+      'oldest': false,
+      'hours': null,
+    }
+  )
 })


### PR DESCRIPTION
Also edited the Codecov report link out from the README, the link is now in Slack. Looks more elegant with just the badge.

Also removed some unnecessary code which was supposed to be used with the Slack modals with message shortcut but then it was implemented without the modal.

Possibly using this branch for the whole sprint when I am documenting the code so dont get tricked by the branch name.